### PR TITLE
Fix auto-refresh table example

### DIFF
--- a/app/Livewire/TableRefresher.php
+++ b/app/Livewire/TableRefresher.php
@@ -8,7 +8,7 @@ class TableRefresher extends Component
 {
     public function refreshTable()
     {
-        $this->dispatch('pg:eventRefresh-dishTable');
+        $this->dispatch('pg:eventRefresh-auto-refresh-table');
     }
 
     public function render()


### PR DESCRIPTION
If you take a look on [Auto Refresh example](https://demo.livewire-powergrid.com/examples/auto-refresh), you will probably notice it's not working

According to doc, the wrong event is dispatched, using `dishTable` instead of `auto-refresh-table`